### PR TITLE
Use console-based OAuth flow for headless Gmail auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This repository scaffolds a strictly local workflow: fetch an email thread from 
 
 4. **Gmail or Microsoft Graph auth (optional at first).**
 
-   * For Gmail, place your `credentials.json` (OAuth client) next to your runner script; first run will open a browser to consent. Use scope `gmail.readonly` until you enable draft creation.
+  * For Gmail, place your `credentials.json` (OAuth client) next to your runner script; the first run will print a URL in the console. Copy it into a browser, authorize the app, and paste the returned code back into the terminal. Use scope `gmail.readonly` until you enable draft creation.
    * For Outlook/Microsoft 365, register an app in Azure AD and set `AZURE_APP_CLIENT_ID` (device‑code flow is simplest during development).
 
 5. **Run your app.** The starter assumes a Flask app binding to `127.0.0.1:7860`. Visit that URL to fetch a thread, paste a draft, and call the local LLM.
@@ -48,7 +48,7 @@ This repository scaffolds a strictly local workflow: fetch an email thread from 
 3. Configure the **OAuth consent screen** (External user type is sufficient for personal/testing use) and add your Gmail address as a test user.
 4. Go to *APIs & Services → Credentials*, click **+ Create Credentials → OAuth client ID**, and choose **Desktop app**.
 5. Download the resulting JSON file and rename it to `credentials.json`.
-6. Place `credentials.json` next to `runner.py`; the first run will launch a browser to complete OAuth and store a token locally.
+6. Place `credentials.json` next to `runner.py`; the first run will output a URL. Visit it in a browser, approve access, and paste the resulting code into the console to store a token locally.
 
 > The JSON file and generated tokens contain secrets—keep them out of version control.
 

--- a/runner.py
+++ b/runner.py
@@ -22,7 +22,7 @@ def gmail_service():
             creds.refresh(Request())
         else:
             flow = InstalledAppFlow.from_client_secrets_file("credentials.json", SCOPES)
-            creds = flow.run_local_server(port=0)
+            creds = flow.run_console()
         pickle.dump(creds, open("token.pickle","wb"))
     return build("gmail","v1",credentials=creds)
 


### PR DESCRIPTION
## Summary
- Switch Gmail OAuth to `flow.run_console()` for headless environments
- Document manual URL copy/paste authorization steps in README

## Testing
- `python -m py_compile runner.py`

------
https://chatgpt.com/codex/tasks/task_e_68ac8d5c2a2c8330be449432ef9f2ad7