### PR TITLE
feat: manual OAuth authorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This repository scaffolds a strictly local workflow: fetch an email thread from 
 
 4. **Gmail or Microsoft Graph auth (optional at first).**
 
-  * For Gmail, place your `credentials.json` (OAuth client) next to your runner script; the first run will print a URL in the console. Copy it into a browser, authorize the app, and paste the returned code back into the terminal. Use scope `gmail.readonly` until you enable draft creation.
+  * For Gmail, place your `credentials.json` (OAuth client) next to your runner script. On first run the script logs an authorization URL instead of opening a browser; copy the link into a browser, authorize the app, and paste the returned code back into the terminal. Use scope `gmail.readonly` until you enable draft creation.
    * For Outlook/Microsoft 365, register an app in Azure AD and set `AZURE_APP_CLIENT_ID` (device‑code flow is simplest during development).
 
 5. **Run your app.** The starter assumes a Flask app binding to `127.0.0.1:7860`. Visit that URL to fetch a thread, paste a draft, and call the local LLM.

--- a/runner.py
+++ b/runner.py
@@ -22,7 +22,11 @@ def gmail_service():
             creds.refresh(Request())
         else:
             flow = InstalledAppFlow.from_client_secrets_file("credentials.json", SCOPES)
-            creds = flow.run_console()
+            auth_url, _ = flow.authorization_url(prompt="consent")
+            print(f"Visit this URL to authorize:\n{auth_url}")
+            auth_code = input("Enter the authorization code: ")
+            flow.fetch_token(code=auth_code)
+            creds = flow.credentials
         pickle.dump(creds, open("token.pickle","wb"))
     return build("gmail","v1",credentials=creds)
 


### PR DESCRIPTION
## Summary
- replace `flow.run_console()` with explicit URL+code OAuth flow
- document manual copy/paste authorization in README

## Testing
- `pytest`
- `python -m py_compile runner.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac9de95d388330bd7339fe01ee0012