### PR TITLE
Pin google-auth-oauthlib to version with run_console

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,8 @@ openai>=1.40
 
 google-api-python-client>=2.130
 google-auth-httplib2>=0.2
-google-auth-oauthlib>=1.2
+google-auth-oauthlib==0.4.1
+six>=1.17
 
 # Microsoft Graph
 


### PR DESCRIPTION
## Summary
- pin google-auth-oauthlib to 0.4.1 so InstalledAppFlow.run_console is available
- add six dependency required by the older oauth flow

## Testing
- `pip install -r requirements.txt`
- `python -c "from google_auth_oauthlib.flow import InstalledAppFlow; print(hasattr(InstalledAppFlow, 'run_console'))"`


------
https://chatgpt.com/codex/tasks/task_e_68ac9dea1bc883308e4a6ea1a9b5cb1c