### PR TITLE
Stream model output live

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository scaffolds a strictly local workflow: fetch an email thread from 
 
 * **Gmail integration.** `runner.py` authenticates with Google via OAuth, retrieves thread contents and can create reply drafts.
 * **Local model interaction.** The assembled prompt (thread, draft, and goal) is sent to a locally hosted model through an OpenAI-compatible endpoint and the model's critique is returned.
-* **Web interface.** Flask routes display the latest thread, accept user drafts/goals, and call the model for tone coaching.
+* **Web interface.** Flask routes display the latest thread, accept user drafts/goals, and stream model coaching output live.
 * **Security posture.** Designed for localhost-only deployment; start with read-only mail scopes and never commit secrets.
 
 ## Quickstart (single‑user, localhost)


### PR DESCRIPTION
## Summary
- stream model tokens from the local LLM to the browser
- add frontend JS to display output progressively
- note streaming web interface in the README

## Testing
- `python -m py_compile runner.py`

------
https://chatgpt.com/codex/tasks/task_e_68acb26dc0bc8330847b02051de75676