### PR TITLE
Use getattr for stream content

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -134,7 +134,7 @@ def coach():
             stream=True,
         )
         for chunk in stream:
-            text = chunk.choices[0].delta.get("content", "")
+            text = getattr(chunk.choices[0].delta, "content", "")
             output += text
             yield text
         beta = output.split("Beta", 1)[-1].strip()


### PR DESCRIPTION
## Summary
- Replace dictionary `get` access with `getattr` for streamed chunk content to avoid attribute errors when `delta` lacks `content`.

## Testing
- `python -m py_compile runner.py`
- `python - <<'PY'
class FakeDelta: pass
class FakeChoice: pass
FakeChoice.delta = FakeDelta()
class FakeChunk: pass
FakeChunk.choices = [FakeChoice]
stream = [FakeChunk(), FakeChunk()]
output = ""
for chunk in stream:
    text = getattr(chunk.choices[0].delta, "content", "")
    output += text
print('Output:', repr(output))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68acb65345608330904d2a21afddbeba