### PR TITLE
Handle HTML-only messages in thread text

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -6,6 +6,7 @@ from google_auth_oauthlib.flow import InstalledAppFlow
 from google.auth.transport.requests import Request
 from openai import OpenAI
 import base64, email, os, pickle, re
+from bs4 import BeautifulSoup
 import dotenv
 
 dotenv.load_dotenv()
@@ -37,17 +38,36 @@ def gmail_service():
     return build("gmail","v1",credentials=creds)
 
 def thread_text(svc, thread_id):
+    def collect_parts(payload):
+        plain_parts, html_parts = [], []
+
+        def walk(part):
+            mime = part.get("mimeType", "")
+            body = part.get("body", {})
+            if mime.startswith("multipart/"):
+                for sp in part.get("parts") or []:
+                    walk(sp)
+            elif mime.startswith("text/plain"):
+                data = body.get("data")
+                if data:
+                    plain_parts.append(
+                        base64.urlsafe_b64decode(data).decode("utf-8", errors="ignore")
+                    )
+            elif mime.startswith("text/html"):
+                data = body.get("data")
+                if data:
+                    html = base64.urlsafe_b64decode(data).decode("utf-8", errors="ignore")
+                    html_parts.append(BeautifulSoup(html, "html.parser").get_text())
+
+        walk(payload)
+        return plain_parts or html_parts
+
     th = svc.users().threads().get(userId="me", id=thread_id, format="full").execute()
     parts = []
     for m in th["messages"]:
-        payload = m["payload"]
-        data = payload.get("body",{}).get("data")
-        if not data:
-            for p in payload.get("parts") or []:
-                if p.get("mimeType","").startswith("text/plain") and p.get("body",{}).get("data"):
-                    data = p["body"]["data"]; break
-        if data:
-            parts.append(base64.urlsafe_b64decode(data).decode("utf-8", errors="ignore"))
+        texts = collect_parts(m["payload"])
+        if texts:
+            parts.append("\n".join(texts))
     return "\n\n---\n\n".join(parts), th
 
 def create_gmail_draft(svc, to_addr, subj, body):


### PR DESCRIPTION
## Summary
- Parse message payloads recursively to gather text/plain and text/html parts
- Strip HTML tags with BeautifulSoup when no plain text is present
- Use new recursive helper so complex emails produce readable thread text

## Testing
- `python -m py_compile runner.py`


------
https://chatgpt.com/codex/tasks/task_e_68acb8dbba5083309233d91c0a7a0cd7