### PR TITLE
Escape and encode search query

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -1,6 +1,7 @@
 # app.py
 # pip install flask google-api-python-client google-auth-oauthlib openai
 from flask import Flask, request, render_template_string, Response, stream_with_context
+from urllib.parse import quote_plus
 from googleapiclient.discovery import build
 from google_auth_oauthlib.flow import InstalledAppFlow
 from google.auth.transport.requests import Request
@@ -63,12 +64,12 @@ TEMPLATE = """
 <title>Tone Coach</title>
 <div style="display:grid;grid-template-columns:1fr 1fr;gap:1rem;font-family:system-ui;">
   <form method="get" action="/">
-    <input style="width:70%" name="q" placeholder="search (e.g., subject:kickoff newer_than:7d)" value="{{q}}"/>
+    <input style="width:70%" name="q" placeholder="search (e.g., subject:kickoff newer_than:7d)" value="{{ q|e }}"/>
     <button>Fetch</button>
     {% if threads %}
     <ul>
     {% for t in threads %}
-      <li><a href="/?q={{q}}&thread_id={{t['id']}}">{{t['snippet']}}</a></li>
+      <li><a href="/?q={{ quote_plus(q)|e }}&thread_id={{t['id']}}">{{t['snippet']}}</a></li>
     {% endfor %}
     </ul>
     {% endif %}
@@ -111,7 +112,16 @@ def index():
     text = ""
     if thread_id:
         text, _ = thread_text(svc, thread_id)
-    return render_template_string(TEMPLATE, thread=text, thread_id=thread_id, draft="", output="", threads=threads, q=q)
+    return render_template_string(
+        TEMPLATE,
+        thread=text,
+        thread_id=thread_id,
+        draft="",
+        output="",
+        threads=threads,
+        q=q,
+        quote_plus=quote_plus,
+    )
 
 @app.route("/coach", methods=["POST"])
 def coach():


### PR DESCRIPTION
## Summary
- Escape search form input with Jinja `|e`
- URL-encode `q` in search result links via `urllib.parse.quote_plus`
- Provide `quote_plus` to template rendering

## Testing
- `python -m py_compile runner.py`
- `python - <<'PY'
from flask import render_template_string
from urllib.parse import urlparse, parse_qs, quote_plus
import runner

q = 'a&b<c"'
threads = [{'id': '123', 'snippet': 'Example'}]
with runner.app.app_context():
    html = render_template_string(runner.TEMPLATE, thread='', thread_id='', draft='', output='', threads=threads, q=q, quote_plus=quote_plus)
import re
href = re.search(r'href="([^"]+)"', html).group(1)
print('href:', href)
from urllib.parse import urlparse, parse_qs
print('decoded q:', parse_qs(urlparse(href).query)['q'][0])
PY`

------
https://chatgpt.com/codex/tasks/task_e_68acb8deb2748330999763aee7a636fc