### PR TITLE
feat: add mad libs reply generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This repository scaffolds a strictly local workflow: fetch an email thread from 
 * **Gmail integration.** `runner.py` authenticates with Google via OAuth, retrieves thread contents and can create reply drafts.
 * **Local model interaction.** The assembled prompt (thread, draft, and goal) is sent to a locally hosted model through an OpenAI-compatible endpoint and the model's critique is returned.
 * **Web interface.** Flask routes display the latest thread, accept user drafts/goals, and stream model coaching output live.
+* **Mad Libs reply.** A second button analyzes the thread for the sender's needs and generates a fill‑in‑the‑blank reply addressing them.
 * **Security posture.** Designed for localhost-only deployment; start with read-only mail scopes and never commit secrets.
 
 ## Quickstart (single‑user, localhost)


### PR DESCRIPTION
## Summary
- add Mad Libs button that analyzes sender needs and drafts a fill-in-the-blank reply
- stream new Mad Libs endpoint and create Gmail draft from template
- document Mad Libs reply feature

## Testing
- `python -m py_compile runner.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b07b1ea73c8330a12787c2660ed8c3