### PR TITLE
Ensure thread text always defined in index

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -146,12 +146,12 @@ def index():
     thread_id = request.args.get("thread_id")
     if not thread_id and threads:
         thread_id = threads[0]["id"]
-    thread_display = ""
+    thread_text = ""
     if thread_id:
-        text, _ = thread_text(svc, thread_id)
+        thread_text, _ = globals()["thread_text"](svc, thread_id)
     return render_template_string(
         TEMPLATE,
-        thread=text,
+        thread=thread_text,
         thread_id=thread_id,
         draft="",
         output="",


### PR DESCRIPTION
## Summary
- Initialize `thread_text` in `index` to avoid undefined variable
- Pass `thread_text` to template rendering for consistent display

## Testing
- `python -m py_compile runner.py`


------
https://chatgpt.com/codex/tasks/task_e_68b07ff94bb0833083f2ccf931608efc