### PR TITLE
Handle empty Gmail thread list gracefully

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -142,16 +142,23 @@ madlibsBtn.addEventListener('click', async () => {
 def index():
     svc = gmail_service()
     q = request.args.get("q") or "in:inbox"            # default heuristic
-    threads = svc.users().threads().list(userId="me", q=q, maxResults=3).execute().get("threads", [])
+    threads = (
+        svc.users()
+        .threads()
+        .list(userId="me", q=q, maxResults=3)
+        .execute()
+        .get("threads", [])
+    )
     thread_id = request.args.get("thread_id")
+    get_thread_text = thread_text  # alias to avoid shadowing
+    thread_text = "No threads found."
     if not thread_id and threads:
         thread_id = threads[0]["id"]
-    thread_display = ""
     if thread_id:
-        text, _ = thread_text(svc, thread_id)
+        thread_text, _ = get_thread_text(svc, thread_id)
     return render_template_string(
         TEMPLATE,
-        thread=text,
+        thread=thread_text,
         thread_id=thread_id,
         draft="",
         output="",


### PR DESCRIPTION
## Summary
- Default to a "No threads found." message when Gmail search returns no threads
- Avoid errors in index route when no thread ID is available

## Testing
- `python -m py_compile runner.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0800295788330b305fffad8ef573b