### PR TITLE
Add vaporwave theme

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -83,30 +83,36 @@ def create_gmail_draft(svc, to_addr, subj, body):
 
 TEMPLATE = """
 <!doctype html>
-<title>Tone Coach</title>
-<div style="display:grid;grid-template-columns:1fr 1fr;gap:1rem;font-family:system-ui;">
-  <form method="get" action="/">
-    <input style="width:70%" name="q" placeholder="search (e.g., subject:kickoff newer_than:7d)" value="{{ q|e }}"/>
-    <button>Fetch</button>
-    {% if threads %}
-    <ul>
-    {% for t in threads %}
-      <li><a href="/?q={{ quote_plus(q)|e }}&thread_id={{t['id']}}">{{t['snippet']}}</a></li>
-    {% endfor %}
-    </ul>
-    {% endif %}
-  </form>
-  <form id="coachForm" method="post" action="/coach">
-    <textarea name="draft" placeholder="Your draft…" style="width:100%;height:8rem;">{{draft or ""}}</textarea>
-    <input name="goal" placeholder="Goal (e.g., confirm ETA, under 120 words)" style="width:100%;"/>
-    <input type="hidden" name="thread_id" value="{{thread_id or ""}}"/>
-    <button>Coach</button>
-    <button type="button" id="madlibsBtn">Identify</button>
-  </form>
-  <div style="white-space:pre-wrap;border:1px solid #ddd;padding:0.75rem;">{{thread or "Thread will appear here."}}</div>
-  <div id="output" style="white-space:pre-wrap;border:1px solid #ddd;padding:0.75rem;">{{output or "Model output will appear here."}}</div>
-</div>
-<script>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Tone Coach</title>
+  <link rel="stylesheet" href="/static/vaporwave.css">
+</head>
+<body class="vaporwave">
+  <div class="grid-container">
+    <form method="get" action="/">
+      <input name="q" placeholder="search (e.g., subject:kickoff newer_than:7d)" value="{{ q|e }}"/>
+      <button>Fetch</button>
+      {% if threads %}
+      <ul>
+      {% for t in threads %}
+        <li><a href="/?q={{ quote_plus(q)|e }}&thread_id={{t['id']}}">{{t['snippet']}}</a></li>
+      {% endfor %}
+      </ul>
+      {% endif %}
+    </form>
+    <form id="coachForm" method="post" action="/coach">
+      <textarea name="draft" placeholder="Your draft…">{{draft or ""}}</textarea>
+      <input name="goal" placeholder="Goal (e.g., confirm ETA, under 120 words)"/>
+      <input type="hidden" name="thread_id" value="{{thread_id or ""}}"/>
+      <button>Coach</button>
+      <button type="button" id="madlibsBtn">Identify</button>
+    </form>
+    <div class="thread-box">{{thread or "Thread will appear here."}}</div>
+    <div id="output" class="output-box">{{output or "Model output will appear here."}}</div>
+  </div>
+  <script>
 const form = document.getElementById('coachForm');
 form.addEventListener('submit', async (e) => {
   e.preventDefault();
@@ -123,19 +129,21 @@ form.addEventListener('submit', async (e) => {
 });
 
 const madlibsBtn = document.getElementById('madlibsBtn');
-madlibsBtn.addEventListener('click', async () => {
-  const output = document.getElementById('output');
-  output.textContent = "";
-  const resp = await fetch('/madlibs', { method: 'POST', body: new FormData(form) });
-  const reader = resp.body.getReader();
-  const decoder = new TextDecoder();
-  while (true) {
-    const { value, done } = await reader.read();
-    if (done) break;
-    output.textContent += decoder.decode(value);
-  }
-});
-</script>
+  madlibsBtn.addEventListener('click', async () => {
+    const output = document.getElementById('output');
+    output.textContent = "";
+    const resp = await fetch('/madlibs', { method: 'POST', body: new FormData(form) });
+    const reader = resp.body.getReader();
+    const decoder = new TextDecoder();
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      output.textContent += decoder.decode(value);
+    }
+  });
+  </script>
+</body>
+</html>
 """
 
 @app.route("/", methods=["GET"])

--- a/static/vaporwave.css
+++ b/static/vaporwave.css
@@ -1,0 +1,49 @@
+body.vaporwave {
+  background: linear-gradient(135deg, #ff71ce, #01cdfe, #fffb96, #b967ff);
+  color: #f5f5f5;
+  font-family: 'Courier New', monospace;
+  min-height: 100vh;
+  margin: 0;
+}
+
+.grid-container {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+  padding: 1rem;
+}
+
+input, textarea, button {
+  background: rgba(255, 255, 255, 0.1);
+  border: 2px solid #ff71ce;
+  color: #f5f5f5;
+  padding: 0.5rem;
+}
+
+button {
+  cursor: pointer;
+}
+
+input[name="q"] {
+  width: 70%;
+}
+
+textarea {
+  width: 100%;
+  height: 8rem;
+}
+
+input[name="goal"] {
+  width: 100%;
+}
+
+.thread-box, .output-box {
+  white-space: pre-wrap;
+  border: 1px solid #ff71ce;
+  padding: 0.75rem;
+  background: rgba(0, 0, 0, 0.3);
+}
+
+a {
+  color: #fffb96;
+}


### PR DESCRIPTION
## Summary
- Introduce vaporwave CSS and link it from the Flask template
- Replace inline styles with themed classes for thread and output boxes

## Testing
- `python -m py_compile runner.py`


------
https://chatgpt.com/codex/tasks/task_e_68b475ed750c8330a140e218f24ae210