### PR TITLE
Enhance UI with vaporwave theme and thread fetching script

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -9,17 +9,53 @@
   <div class="grid-container">
     <div>
       <input class="search" value="in:inbox" placeholder="search" />
-      <button class="btn">Fetch</button>
+      <button class="btn fetch-btn">Fetch</button>
       <ul class="threads"></ul>
     </div>
     <div>
       <textarea placeholder="Your draft…"></textarea>
       <input class="goal" placeholder="Goal (e.g., confirm ETA, under 120 words)" />
-      <button class="btn">Coach</button>
-      <button class="btn">Identify</button>
+      <button class="btn coach-btn">Coach</button>
+      <button class="btn identify-btn">Identify</button>
     </div>
     <div class="thread-box">Thread will appear here.</div>
     <div class="output-box">Model output will appear here.</div>
   </div>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const fetchBtn = document.querySelector('.fetch-btn');
+      const threadList = document.querySelector('.threads');
+      const threadBox = document.querySelector('.thread-box');
+
+      fetchBtn.addEventListener('click', () => {
+        const q = document.querySelector('input.search').value;
+        fetch(`/api/threads?q=${encodeURIComponent(q)}`)
+          .then(r => r.json())
+          .then(threads => {
+            threadList.innerHTML = '';
+            threads.forEach(t => {
+              const li = document.createElement('li');
+              const a = document.createElement('a');
+              a.href = '#';
+              a.dataset.id = t.id;
+              a.textContent = t.snippet || t.id;
+              li.appendChild(a);
+              threadList.appendChild(li);
+            });
+          });
+      });
+
+      threadList.addEventListener('click', (e) => {
+        const id = e.target.dataset.id;
+        if (!id) return;
+        e.preventDefault();
+        fetch(`/api/thread/${id}`)
+          .then(r => r.json())
+          .then(data => {
+            threadBox.textContent = data.thread;
+          });
+      });
+    });
+  </script>
 </body>
 </html>

--- a/static/vaporwave.css
+++ b/static/vaporwave.css
@@ -1,6 +1,6 @@
 body.vaporwave {
-  background: linear-gradient(135deg, #ff71ce, #01cdfe, #fffb96, #b967ff);
-  color: #f5f5f5;
+  background: linear-gradient(135deg, #ff9de6, #a1c4fd, #c2ffd8, #f3d9ff);
+  color: #1a1a1a;
   font-family: 'Courier New', monospace;
   min-height: 100vh;
   margin: 0;
@@ -13,25 +13,27 @@ body.vaporwave {
   padding: 1rem;
 }
 
-input, textarea, button {
-  background: rgba(255, 255, 255, 0.1);
+input, textarea {
+  background: rgba(255, 255, 255, 0.8);
   border: 2px solid #ff71ce;
-  color: #f5f5f5;
+  color: #1a1a1a;
   padding: 0.5rem;
   border-radius: 4px;
 }
 
-button {
-  cursor: pointer;
+button.btn {
+  background: #ff71ce;
+  border: none;
+  color: #1a1a1a;
   padding: 0.5rem 1rem;
+  border-radius: 4px;
   font-weight: bold;
   box-shadow: 0 0 10px rgba(255, 113, 206, 0.7);
-  transition: background 0.3s, transform 0.2s, box-shadow 0.3s;
+  cursor: pointer;
+  transition: transform 0.2s, box-shadow 0.3s;
 }
 
-button:hover {
-  background: #ff71ce;
-  color: #1a1a1a;
+button.btn:hover {
   transform: translateY(-2px);
   box-shadow: 0 0 20px rgba(255, 113, 206, 0.9);
 }
@@ -53,10 +55,33 @@ input.goal {
   white-space: pre-wrap;
   border: 1px solid #ff71ce;
   padding: 0.75rem;
-  background: rgba(0, 0, 0, 0.3);
+  background: rgba(255, 255, 255, 0.6);
   border-radius: 4px;
 }
 
 a {
   color: #fffb96;
+}
+
+.threads {
+  list-style: none;
+  padding: 0;
+}
+
+.threads li {
+  margin: 0.25rem 0;
+}
+
+.threads a {
+  display: block;
+  padding: 0.25rem 0.5rem;
+  background: rgba(255, 255, 255, 0.8);
+  border-radius: 4px;
+  color: #1a1a1a;
+  text-decoration: none;
+}
+
+.threads a:hover {
+  background: #ff71ce;
+  color: #1a1a1a;
 }


### PR DESCRIPTION
## Summary
- Restyle UI with a softer vaporwave gradient and solid color buttons for better contrast.
- Add thread list styles so top search results are displayed cleanly.
- Introduce front-end script to fetch Gmail threads and load selected thread content.

## Testing
- `python -m py_compile runner.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4c58c4eb48330899cac76c9aad575