### PR TITLE
Merge thread view with inbox and expand output panel

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -28,6 +28,8 @@
         </button>
       </div>
       <ul class="threads"></ul>
+      <div class="panel-title">Thread</div>
+      <div class="thread-box">Thread will appear here.</div>
     </section>
 
     <section class="panel panel--compose">
@@ -47,11 +49,6 @@
           <span>Identify</span>
         </button>
       </div>
-    </section>
-
-    <section class="panel panel--thread">
-      <div class="panel-title">Thread</div>
-      <div class="thread-box">Thread will appear here.</div>
     </section>
 
     <section class="panel panel--output">

--- a/static/vaporwave.css
+++ b/static/vaporwave.css
@@ -79,10 +79,10 @@ body.vaporwave{
 /* Grid layout */
 .grid-container{
   display:grid;
-  grid-template-columns: 1.1fr 1.3fr 1.2fr;
+  grid-template-columns: 1fr 1fr;
   grid-template-areas:
-    "inbox compose thread"
-    "inbox compose output";
+    "inbox output"
+    "compose output";
   gap: clamp(14px, 1.8vw, 22px);
   padding: clamp(16px, 2.2vw, 28px);
   max-width: 1400px;
@@ -109,7 +109,6 @@ body.vaporwave{
 }
 .panel--inbox{ grid-area: inbox; display:flex; flex-direction:column; gap:12px; }
 .panel--compose{ grid-area: compose; display:flex; flex-direction:column; gap:12px; }
-.panel--thread{ grid-area: thread; display:flex; flex-direction:column; gap:10px; }
 .panel--output{ grid-area: output; display:flex; flex-direction:column; gap:10px; }
 
 .panel-title{
@@ -289,21 +288,12 @@ textarea{
 *::-webkit-scrollbar-track{ background: rgba(255,255,255,.15); border-radius: 999px; }
 
 /* Responsive */
-@media (max-width: 1120px){
-  .grid-container{
-    grid-template-columns: 1fr 1fr;
-    grid-template-areas:
-      "inbox compose"
-      "thread output";
-  }
-}
 @media (max-width: 740px){
   .grid-container{
     grid-template-columns: 1fr;
     grid-template-areas:
       "inbox"
       "compose"
-      "thread"
       "output";
   }
   .field-row{ flex-direction:column; align-items:stretch; }


### PR DESCRIPTION
## Summary
- Combine fetch controls and thread display into a single left panel
- Expand model output panel to occupy the full right column
- Simplify responsive layout and remove unused thread panel styles

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b4f05a72448330864eb01ccf05ac8d