### PR TITLE
Scrub URLs to bare domains before prompting

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This repository scaffolds a strictly local workflow: fetch an email thread from 
 * **Local model interaction.** The assembled prompt (thread, draft, and goal) is sent to a locally hosted model through an OpenAI-compatible endpoint and the model's critique is returned.
 * **Web interface.** A small vanilla JS front-end talks to Flask endpoints to fetch threads, submit drafts/goals, and stream coaching output.
 * **Mad Libs reply.** A second button analyzes the thread for the sender's needs and generates a fill‑in‑the‑blank reply addressing them.
+* **Link scrubbing.** Any `http(s)` links in the thread are reduced to their bare domains before being sent to the model.
 * **Security posture.** Designed for localhost-only deployment; start with read-only mail scopes and never commit secrets.
 
 ## Quickstart (single‑user, localhost)

--- a/test_scrub_links.py
+++ b/test_scrub_links.py
@@ -1,0 +1,22 @@
+import unittest
+
+from runner import scrub_links
+
+
+class ScrubLinksTests(unittest.TestCase):
+    def test_link_reduced_to_domain(self):
+        self.assertEqual(
+            scrub_links("https://linkedin.com/long/path?query=123"),
+            "linkedin.com",
+        )
+
+    def test_links_inside_text(self):
+        text = (
+            "Visit https://linkedin.com/long/path?query=123 and http://example.org/foo."
+        )
+        expected = "Visit linkedin.com and example.org."
+        self.assertEqual(scrub_links(text), expected)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `scrub_links` helper to strip URL paths down to domains
- sanitize coach and madlibs thread text with `scrub_links`
- document link scrubbing and add unit tests

## Testing
- `python -m unittest`
- `flake8` *(fails: line length and whitespace issues in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68b4f47b81648330b4dcf9bfef86dc68