### PR TITLE
Lower horizon haze z-index to reveal grid lines

### DIFF
--- a/static/vaporwave.css
+++ b/static/vaporwave.css
@@ -115,7 +115,7 @@ body.vaporwave::after{
   content:"";
   position:fixed; inset:auto 0 30vh 0;
   height: 24vh;
-  z-index: 1;
+  z-index: 0;
   background: radial-gradient(60% 100% at 50% 0%,
               rgba(255,255,255,0.35), rgba(255,255,255,0.0) 70%);
   filter: blur(8px) saturate(115%);


### PR DESCRIPTION
## Summary
- Prevent horizon haze pseudo-element from covering neon grid by lowering its z-index

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4f59bcecc8330986d4d2a670ea2d9