### PR TITLE
Adjust grid layout to prevent stacking

### DIFF
--- a/static/vaporwave.css
+++ b/static/vaporwave.css
@@ -150,7 +150,8 @@ body.vaporwave::after{
 /* Grid layout */
 .grid-container {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
+  /* Allow three panels to sit side‑by‑side on typical desktop widths */
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
   gap: 24px; /* a bit more breathing room */
   max-width: 1440px;
   margin: 0 auto;


### PR DESCRIPTION
## Summary
- ensure panels display side-by-side on typical desktop widths by reducing grid column minimum size

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b50978177c8330948fc2b5e4d0629b