### PR TITLE
Ensure panel order via CSS grid-template-areas

### DIFF
--- a/static/vaporwave.css
+++ b/static/vaporwave.css
@@ -160,6 +160,7 @@ body.vaporwave::after{
   display:grid;
   gap:24px;
   grid-template-columns: repeat(3, minmax(420px, 1fr));
+  grid-template-areas: 'inbox compose output';
   max-width: min(96vw, 1440px);
   margin: 0 auto;
   padding: 2rem;
@@ -169,12 +170,19 @@ body.vaporwave::after{
 @media (max-width: 1320px){
   .grid-container{
     grid-template-columns: repeat(2, minmax(420px, 1fr));
+    grid-template-areas:
+      'inbox compose'
+      'output output';
   }
 }
 
 @media (max-width: 880px){
   .grid-container{
     grid-template-columns: minmax(320px, 1fr);
+    grid-template-areas:
+      'inbox'
+      'compose'
+      'output';
   }
 }
 


### PR DESCRIPTION
## Summary
- Add explicit grid-template-areas to `.grid-container` so inbox, compose, and output panels stay put even if DOM order changes
- Define responsive grid area layouts for two- and one-column breakpoints

## Testing
- `pytest`
- Playwright script verifying panel positions across 1500, 1000, and 800px widths before and after DOM reorder


------
https://chatgpt.com/codex/tasks/task_e_68b5938c684883308241593306dfe7ea