### PR TITLE
fix: allow gradient to scroll with page

### DIFF
--- a/static/vaporwave.css
+++ b/static/vaporwave.css
@@ -21,7 +21,7 @@
 }
 
 *{box-sizing:border-box}
-html,body{height:100%}
+html,body{min-height:100%}
 
 /* Ensure content sits above the background layers */
 .site-header, .grid-container, .site-footer {


### PR DESCRIPTION
## Summary
- avoid fixing root html/body height in vaporwave theme to prevent background gradient loops

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b59a9fc16883309e04315b5007071e