### PR TITLE
Add switch for OpenAI API usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository scaffolds a strictly local workflow: fetch an email thread from 
 ## How it works
 
 * **Gmail integration.** `runner.py` authenticates with Google via OAuth, retrieves thread contents and can create reply drafts.
-* **Local model interaction.** The assembled prompt (thread, draft, and goal) is sent to a locally hosted model through an OpenAI-compatible endpoint and the model's critique is returned.
+* **Model interaction.** The assembled prompt (thread, draft, and goal) is sent either to a locally hosted model via an OpenAI-compatible endpoint or to OpenAI's API, and the model's critique is returned.
 * **Web interface.** A small vanilla JS front-end talks to Flask endpoints to fetch threads, submit drafts/goals, and stream coaching output.
 * **Mad Libs reply.** A second button analyzes the thread for the sender's needs and generates a fill‑in‑the‑blank reply addressing them.
 * **Link scrubbing.** Any `http(s)` links in the thread are reduced to their bare domains before being sent to the model.
@@ -35,8 +35,9 @@ This repository scaffolds a strictly local workflow: fetch an email thread from 
 
 3. **Configure environment.** Copy `.env.example` ➜ `.env` and set values. At minimum:
 
-   * `LLM_BASE_URL` (e.g., `http://127.0.0.1:11434/v1`)
-   * `LLM_MODEL` (e.g., `llama3.1` or `qwen2.5:14b-instruct`)
+   * `LLM_URL` (e.g., `http://127.0.0.1:11434/v1`)
+   * `MODEL` (e.g., `llama3.1` or `qwen2.5:14b-instruct`)
+   * To call OpenAI's hosted models instead of a local server, set `USE_OPENAI=true` and provide `OPENAI_API_KEY` (optionally `OPENAI_MODEL`).
 
 4. **Gmail or Microsoft Graph auth (optional at first).**
 

--- a/env.example
+++ b/env.example
@@ -1,28 +1,28 @@
 # .env.example
 
 # Flask app
-
-FLASK\_HOST=127.0.0.1
-FLASK\_PORT=7860
+FLASK_HOST=127.0.0.1
+FLASK_PORT=7860
 
 # Local LLM endpoint
+LLM_URL=http://127.0.0.1:11434/v1
+MODEL=llama3.1
 
-LLM\_BASE\_URL=[http://127.0.0.1:11434/v1](http://127.0.0.1:11434/v1)
-LLM\_MODEL=llama3.1
+# Use OpenAI instead of a local model
+USE_OPENAI=false
+OPENAI_API_KEY=
+OPENAI_MODEL=gpt-4o-mini
 
-# Gmail OAuth scopes: start read‑only; upgrade to modify for drafts
-
-GOOGLE\_SCOPES=[https://www.googleapis.com/auth/gmail.readonly](https://www.googleapis.com/auth/gmail.readonly)
+# Gmail OAuth scopes: start read-only; upgrade to modify for drafts
+SCOPES=https://www.googleapis.com/auth/gmail.readonly
 
 # Microsoft Graph
-
-AZURE\_TENANT=common
-AZURE\_APP\_CLIENT\_ID=
-MS\_GRAPH\_SCOPES=Mail.Read
+AZURE_TENANT=common
+AZURE_APP_CLIENT_ID=
+MS_GRAPH_SCOPES=Mail.Read
 
 # IMAP (optional; e.g., Proton Mail Bridge on localhost)
-
-IMAP\_HOST=127.0.0.1
-IMAP\_PORT=1143
-IMAP\_USER=
-IMAP\_PASS=
+IMAP_HOST=127.0.0.1
+IMAP_PORT=1143
+IMAP_USER=
+IMAP_PASS=


### PR DESCRIPTION
## Summary
- add env toggle to select between local LLM endpoint and OpenAI API
- document new USE_OPENAI/OPENAI_API_KEY configuration

## Testing
- `python -m pytest -q`
- `python -m flake8 runner.py` *(fails: style issues)*

------
https://chatgpt.com/codex/tasks/task_e_68b5d8767b38833096e1681d7dcd4723