### PR TITLE
Add model response timer

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -53,6 +53,7 @@
 
     <section class="panel panel--output">
       <div class="panel-title">Model Output</div>
+      <div class="timer">0.0s</div>
       <div class="output-box">Model output will appear here.</div>
     </section>
   </main>
@@ -69,8 +70,26 @@
       const coachBtn = document.querySelector('.coach-btn');
       const identifyBtn = document.querySelector('.identify-btn');
       const outputBox = document.querySelector('.output-box');
+      const timerEl = document.querySelector('.timer');
       const draftInput = document.querySelector('#draft');
       const goalInput = document.querySelector('.goal');
+
+      let timerHandle;
+
+      function startTimer() {
+        const start = performance.now();
+        timerEl.textContent = '0.0s';
+        timerEl.style.visibility = 'visible';
+        timerHandle = setInterval(() => {
+          const elapsed = (performance.now() - start) / 1000;
+          timerEl.textContent = `${elapsed.toFixed(1)}s`;
+        }, 100);
+      }
+
+      function stopTimer() {
+        clearInterval(timerHandle);
+        timerHandle = null;
+      }
 
       fetchBtn.addEventListener('click', () => {
         const q = document.querySelector('input.search').value;
@@ -123,10 +142,12 @@
         form.append('goal', goalInput.value);
         coachBtn.disabled = true;
         coachBtn.querySelector('span:last-child').textContent = 'Coaching…';
+        startTimer();
         try {
           const resp = await fetch('/coach', { method: 'POST', body: form });
           await streamResponse(resp);
         } finally {
+          stopTimer();
           coachBtn.disabled = false;
           coachBtn.querySelector('span:last-child').textContent = 'Coach';
         }
@@ -139,10 +160,12 @@
         form.append('thread_id', active.dataset.id);
         identifyBtn.disabled = true;
         identifyBtn.querySelector('span:last-child').textContent = 'Identifying…';
+        startTimer();
         try {
           const resp = await fetch('/madlibs', { method: 'POST', body: form });
           await streamResponse(resp);
         } finally {
+          stopTimer();
           identifyBtn.disabled = false;
           identifyBtn.querySelector('span:last-child').textContent = 'Identify';
         }

--- a/static/vaporwave.css
+++ b/static/vaporwave.css
@@ -263,7 +263,17 @@ body.vaporwave::after{
 }
 .panel--inbox{ grid-area: inbox; display:flex; flex-direction:column; gap:12px; }
 .panel--compose{ grid-area: compose; display:flex; flex-direction:column; gap:12px; }
-.panel--output{ grid-area: output; display:flex; flex-direction:column; gap:10px; }
+.panel--output{ grid-area: output; display:flex; flex-direction:column; gap:10px; position:relative; }
+
+.panel--output .timer{
+  position:absolute;
+  top:4px;
+  right:8px;
+  font-family:Orbitron, Inter, sans-serif;
+  font-size:12px;
+  color:var(--neon-cyan);
+  visibility:hidden;
+}
 
 .panel-title{
   font-family: Orbitron, Inter, sans-serif;


### PR DESCRIPTION
## Summary
- overlay a timer on model output panel
- start timer on request, stop when stream completes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5d946d92c8330905cd8928cce271d