### PR TITLE
Show subject or first line in email previews

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -106,13 +106,38 @@ def serve_ui():
 def api_threads():
     svc = gmail_service()
     q = request.args.get("q") or "in:inbox"
-    threads = (
+    thread_refs = (
         svc.users()
         .threads()
         .list(userId="me", q=q, maxResults=3)
         .execute()
         .get("threads", [])
     )
+    threads = []
+    for t in thread_refs:
+        meta = (
+            svc.users()
+            .threads()
+            .get(
+                userId="me",
+                id=t["id"],
+                format="metadata",
+                metadataHeaders=["Subject"],
+            )
+            .execute()
+        )
+        subject = ""
+        snippet = ""
+        msgs = meta.get("messages", [])
+        if msgs:
+            m0 = msgs[0]
+            headers = m0["payload"].get("headers", [])
+            subject = next(
+                (h["value"] for h in headers if h["name"].lower() == "subject"),
+                "",
+            )
+            snippet = BeautifulSoup(m0.get("snippet", ""), "html.parser").get_text()
+        threads.append({"id": t["id"], "subject": subject, "snippet": snippet})
     return jsonify(threads)
 
 

--- a/static/index.html
+++ b/static/index.html
@@ -83,7 +83,7 @@
               const a = document.createElement('a');
               a.href = '#';
               a.dataset.id = t.id;
-              a.textContent = t.snippet || t.id;
+              a.textContent = t.subject || t.snippet || t.id;
               li.appendChild(a);
               threadList.appendChild(li);
             });


### PR DESCRIPTION
## Summary
- Return each thread's subject with a cleaned first-line snippet fallback
- Display subject or snippet in the thread list while preserving body view on click

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5d9b780148330a953ab01bf3304ff