### PR TITLE
Strip HTML tags and excess blank lines before model call

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This repository scaffolds a strictly local workflow: fetch an email thread from 
 * **Model interaction.** The assembled prompt (thread, draft, and goal) is sent either to a locally hosted model via an OpenAI-compatible endpoint or to OpenAI's API, and the model's critique is returned.
 * **Web interface.** A small vanilla JS front-end talks to Flask endpoints to fetch threads, submit drafts/goals, and stream coaching output.
 * **Mad Libs reply.** A second button analyzes the thread for the sender's needs and generates a fill‑in‑the‑blank reply addressing them.
+* **Formatting cleanup.** Basic HTML tags and excessive blank lines are stripped before sending text to the model.
 * **Link scrubbing.** Any `http(s)` links in the thread are reduced to their bare domains before being sent to the model.
 * **Security posture.** Designed for localhost-only deployment; start with read-only mail scopes and never commit secrets.
 

--- a/test_scrub_formatting.py
+++ b/test_scrub_formatting.py
@@ -1,0 +1,22 @@
+import unittest
+
+from runner import scrub_formatting
+
+
+class ScrubFormattingTests(unittest.TestCase):
+    def test_html_tags_removed(self):
+        self.assertEqual(scrub_formatting("Hello <b>World</b>"), "Hello World")
+
+    def test_collapse_blank_lines(self):
+        text = "Line1\n\n\nLine2"
+        expected = "Line1\n\nLine2"
+        self.assertEqual(scrub_formatting(text), expected)
+
+    def test_preserve_email_addresses(self):
+        text = "Contact <john@doe.com> for info"
+        self.assertIn("john@doe.com", scrub_formatting(text))
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- remove basic HTML tags and collapse excessive blank lines from email threads
- apply formatting scrub in coach and madlibs flows
- document formatting cleanup and add unit tests

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5dba007fc8330927e04598a7c64c7