### PR TITLE
Auto fetch important Gmail threads on startup

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -120,7 +120,7 @@ def serve_ui():
 @app.route("/api/threads", methods=["GET"])
 def api_threads():
     svc = gmail_service()
-    q = request.args.get("q") or "in:inbox"
+    q = request.args.get("q") or "is:important"
     thread_refs = (
         svc.users()
         .threads()

--- a/static/index.html
+++ b/static/index.html
@@ -21,7 +21,7 @@
   <main class="grid-container">
     <section class="panel panel--inbox">
       <div class="field-row">
-        <input class="search" value="in:inbox" placeholder="Search threads (e.g., from:alice after:2025/08/01)" />
+        <input class="search" value="is:important" placeholder="Search threads (e.g., from:alice after:2025/08/01)" />
         <button class="btn btn--primary fetch-btn">
           <span class="btn-glow"></span>
           <span>Fetch</span>
@@ -73,6 +73,7 @@
       const timerEl = document.querySelector('.timer');
       const draftInput = document.querySelector('#draft');
       const goalInput = document.querySelector('.goal');
+      const searchInput = document.querySelector('input.search');
 
       let timerHandle;
 
@@ -91,8 +92,7 @@
         timerHandle = null;
       }
 
-      fetchBtn.addEventListener('click', () => {
-        const q = document.querySelector('input.search').value;
+      function loadThreads(q) {
         fetch(`/api/threads?q=${encodeURIComponent(q)}`)
           .then(r => r.json())
           .then(threads => {
@@ -107,7 +107,15 @@
               threadList.appendChild(li);
             });
           });
+      }
+
+      fetchBtn.addEventListener('click', () => {
+        loadThreads(searchInput.value);
       });
+
+      // Auto-fetch important threads on startup
+      searchInput.value = 'is:important';
+      loadThreads('is:important');
 
       threadList.addEventListener('click', (e) => {
         const id = e.target.dataset.id;


### PR DESCRIPTION
## Summary
- Fetch Gmail threads tagged `is:important` automatically when the UI loads
- Add `loadThreads` helper and default search value `is:important`
- Use `is:important` as the default query for `/api/threads`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5dc29eee08330ba99351ed4b4c858