### PR TITLE
Match Draft and Goal label fonts with other headers

### DIFF
--- a/static/vaporwave.css
+++ b/static/vaporwave.css
@@ -286,6 +286,8 @@ body.vaporwave::after{
 
 /* Fields */
 .label{
+  font-family: Orbitron, Inter, sans-serif;
+  font-weight:600;
   font-size:12px;
   letter-spacing:0.04em;
   text-transform:uppercase;


### PR DESCRIPTION
## Summary
- Use Orbitron font for Draft and Goal labels so they match other text box headers

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5df19eac8833094b43e6156c1aae1