### PR TITLE
Expand grid beyond viewport

### DIFF
--- a/static/vaporwave.css
+++ b/static/vaporwave.css
@@ -87,9 +87,9 @@ body.vaporwave::after{
 /* Neon grid “floor” */
 .bg-grid{
   position: fixed;
-  /* use viewport-relative offsets for consistent centering */
-  left: calc(var(--vw) * -50);
-  right: calc(var(--vw) * -50);
+  /* extend far beyond viewport so edges never appear */
+  left: calc(var(--vw) * -200);
+  right: calc(var(--vw) * -200);
   bottom: calc(var(--vh) * -20);
   height: calc(var(--vh) * 220);
 


### PR DESCRIPTION
## Summary
- widen vaporwave background grid to ensure edges remain off-screen

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b5e0aff4a88330884f420f93390a61