### PR TITLE
Add token usage logging for LLM prompts and responses

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@
 flask==3.1.2
 python-dotenv==1.1.1
 openai==1.101.0
+tiktoken==0.7.0
 
 # Gmail
 


### PR DESCRIPTION
## Summary
- add `tiktoken` dependency and helpers to log token counts
- record OpenAI usage from streamed responses and fall back to tokenizer counts for local models
- output token usage for prompts and completions

## Testing
- `pip install tiktoken==0.7.0`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5df31165083309d22ac94ddd39e77