### PR TITLE
Increase grid square size and shrink grid width

### DIFF
--- a/static/vaporwave.css
+++ b/static/vaporwave.css
@@ -88,16 +88,16 @@ body.vaporwave::after{
 .bg-grid{
   position: fixed;
   /* extend far beyond viewport so edges never appear */
-  left: calc(var(--vw) * -200);
-  right: calc(var(--vw) * -200);
+  left: calc(var(--vw) * -150);
+  right: calc(var(--vw) * -150);
   bottom: calc(var(--vh) * -20);
   height: calc(var(--vh) * 220);
 
   z-index: 1; pointer-events: none; will-change: transform;
 
   background:
-    repeating-linear-gradient(to right, rgba(1,241,248,.9) 0 5px, rgba(1,241,248,0) 5px 120px),
-    repeating-linear-gradient(to bottom, rgba(1,241,248,.9) 0 5px, rgba(1,241,248,0) 5px 120px);
+    repeating-linear-gradient(to right, rgba(1,241,248,.9) 0 5px, rgba(1,241,248,0) 5px 300px),
+    repeating-linear-gradient(to bottom, rgba(1,241,248,.9) 0 5px, rgba(1,241,248,0) 5px 300px);
   filter: drop-shadow(0 0 10px rgba(1,241,248,.4)) drop-shadow(0 0 14px rgba(1,241,248,.32));
 
   transform-origin: 50% 100%;
@@ -117,8 +117,8 @@ body.vaporwave::after{
     opacity:0.65;
     background:
       linear-gradient(to bottom, var(--sky-c) 0%, transparent 60%),
-      repeating-linear-gradient(to right, rgba(1,241,248,.9) 0 5px, rgba(1,241,248,0) 5px 120px),
-      repeating-linear-gradient(to bottom, rgba(1,241,248,.9) 0 5px, rgba(1,241,248,0) 5px 120px);
+      repeating-linear-gradient(to right, rgba(1,241,248,.9) 0 5px, rgba(1,241,248,0) 5px 300px),
+      repeating-linear-gradient(to bottom, rgba(1,241,248,.9) 0 5px, rgba(1,241,248,0) 5px 300px);
   }
 }
 
@@ -169,10 +169,10 @@ body.vaporwave::after{
   }
 }
 
-/* tuned to 80px cell period above */
+/* tuned to larger 300px cell period above */
 @keyframes gridDrift{
   0%   { background-position: 0 0, 0 0; }
-  100% { background-position: 80px 160px, 0 160px; }
+  100% { background-position: 200px 400px, 0 400px; }
 }
 
 @keyframes sunFloat{


### PR DESCRIPTION
## Summary
- Reduce background grid width for a tighter effect
- Expand grid square spacing to cut down on the number of rendered lines
- Retune grid drift animation for the new square size

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5e2c5fa448330a6a036cdcc34a5d5