### PR TITLE
Increase background grid line thickness

### DIFF
--- a/static/vaporwave.css
+++ b/static/vaporwave.css
@@ -96,8 +96,8 @@ body.vaporwave::after{
   z-index: 1; pointer-events: none; will-change: transform;
 
   background:
-    repeating-linear-gradient(to right, rgba(1,241,248,.9) 0 5px, rgba(1,241,248,0) 5px 300px),
-    repeating-linear-gradient(to bottom, rgba(1,241,248,.9) 0 5px, rgba(1,241,248,0) 5px 300px);
+    repeating-linear-gradient(to right, rgba(1,241,248,.9) 0 10px, rgba(1,241,248,0) 10px 300px),
+    repeating-linear-gradient(to bottom, rgba(1,241,248,.9) 0 10px, rgba(1,241,248,0) 10px 300px);
   filter: drop-shadow(0 0 10px rgba(1,241,248,.4)) drop-shadow(0 0 14px rgba(1,241,248,.32));
 
   transform-origin: 50% 100%;
@@ -117,8 +117,8 @@ body.vaporwave::after{
     opacity:0.65;
     background:
       linear-gradient(to bottom, var(--sky-c) 0%, transparent 60%),
-      repeating-linear-gradient(to right, rgba(1,241,248,.9) 0 5px, rgba(1,241,248,0) 5px 300px),
-      repeating-linear-gradient(to bottom, rgba(1,241,248,.9) 0 5px, rgba(1,241,248,0) 5px 300px);
+      repeating-linear-gradient(to right, rgba(1,241,248,.9) 0 10px, rgba(1,241,248,0) 10px 300px),
+      repeating-linear-gradient(to bottom, rgba(1,241,248,.9) 0 10px, rgba(1,241,248,0) 10px 300px);
   }
 }
 


### PR DESCRIPTION
## Summary
- thicken neon grid background lines from 5px to 10px for better visibility

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b61c1e9c8c833083a3a8b8411b837e