### PR TITLE
Add OpenAI pricing-based cost logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This repository scaffolds a strictly local workflow: fetch an email thread from 
 * **Mad Libs reply.** A second button analyzes the thread for the sender's needs and generates a fill‑in‑the‑blank reply addressing them.
 * **Formatting cleanup.** Basic HTML tags and excessive blank lines are stripped before sending text to the model.
 * **Link scrubbing.** Any `http(s)` links in the thread are reduced to their bare domains before being sent to the model.
+* **Cost logging.** When using OpenAI, token usage and estimated cost (May 2024 pricing) are logged.
 * **Security posture.** Designed for localhost-only deployment; start with read-only mail scopes and never commit secrets.
 
 ## Quickstart (single‑user, localhost)


### PR DESCRIPTION
## Summary
- log OpenAI token usage costs using May 2024 pricing
- document cost logging feature in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b61cb267748330aca439f7d9c358ad