### PR TITLE
Cache vaporwave background with canvas

### DIFF
--- a/static/bg-cache.js
+++ b/static/bg-cache.js
@@ -1,0 +1,78 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const rootStyles = getComputedStyle(document.documentElement);
+
+  function makeGridImages() {
+    const size = 300;
+    const color = 'rgba(1,241,248,0.9)';
+
+    const vCanvas = document.createElement('canvas');
+    vCanvas.width = size;
+    vCanvas.height = size;
+    const vCtx = vCanvas.getContext('2d');
+    vCtx.fillStyle = color;
+    vCtx.fillRect(0, 0, 10, size);
+    const vURL = vCanvas.toDataURL();
+
+    const hCanvas = document.createElement('canvas');
+    hCanvas.width = size;
+    hCanvas.height = size;
+    const hCtx = hCanvas.getContext('2d');
+    hCtx.fillStyle = color;
+    hCtx.fillRect(0, 0, size, 10);
+    const hURL = hCanvas.toDataURL();
+
+    return { vURL, hURL };
+  }
+
+  function makeSunImage() {
+    const size = 512;
+    const canvas = document.createElement('canvas');
+    canvas.width = canvas.height = size;
+    const ctx = canvas.getContext('2d');
+
+    const core = rootStyles.getPropertyValue('--sun-core').trim() || '#ffd29a';
+    const rim = rootStyles.getPropertyValue('--sun-rim').trim() || '#ff6a4d';
+
+    const grad = ctx.createRadialGradient(size / 2, size / 2, 0, size / 2, size / 2, size / 2);
+    grad.addColorStop(0, '#fff6d2');
+    grad.addColorStop(0.38, core);
+    grad.addColorStop(0.62, '#ff9c66');
+    grad.addColorStop(0.85, rim);
+    grad.addColorStop(1, 'rgba(255,106,77,0)');
+    ctx.fillStyle = grad;
+    ctx.fillRect(0, 0, size, size);
+
+    // mask with circle and scanlines
+    const mask = document.createElement('canvas');
+    mask.width = mask.height = size;
+    const mCtx = mask.getContext('2d');
+    mCtx.fillStyle = '#000';
+    mCtx.beginPath();
+    mCtx.arc(size / 2, size / 2, size / 2, 0, Math.PI * 2);
+    mCtx.closePath();
+    mCtx.fill();
+    mCtx.globalCompositeOperation = 'destination-in';
+    for (let y = 0; y < size; y += 16) {
+      mCtx.fillRect(0, y, size, 10);
+    }
+    ctx.globalCompositeOperation = 'destination-in';
+    ctx.drawImage(mask, 0, 0);
+
+    return canvas.toDataURL();
+  }
+
+  const gridEl = document.querySelector('.bg-grid');
+  if (gridEl) {
+    const { vURL, hURL } = makeGridImages();
+    gridEl.style.backgroundImage = `url(${vURL}), url(${hURL})`;
+    gridEl.style.backgroundSize = '300px 300px, 300px 300px';
+  }
+
+  const sunEl = document.querySelector('.bg-sunset');
+  if (sunEl) {
+    const sunURL = makeSunImage();
+    sunEl.style.backgroundImage = `url(${sunURL})`;
+    sunEl.style.webkitMask = 'none';
+    sunEl.style.mask = 'none';
+  }
+});

--- a/static/index.html
+++ b/static/index.html
@@ -7,6 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;600;800&family=Inter:wght@400;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/static/vaporwave.css">
+  <script src="/static/bg-cache.js" defer></script>
 </head>
 <body class="vaporwave">
   <!-- New animated background layers -->

--- a/static/vaporwave.css
+++ b/static/vaporwave.css
@@ -70,7 +70,7 @@ body.vaporwave{
     repeating-linear-gradient(to bottom, #000 0 10px, transparent 10px 16px);
   -webkit-mask-composite: source-in; /* keep stripes inside the circle */
           mask-composite: intersect;
-  animation: sunFloat 16s ease-in-out infinite alternate;
+  animation: sunFloat 16s steps(120) infinite alternate;
 }
 
 /* Horizon haze sits between sky and grid to soften the join */
@@ -98,6 +98,7 @@ body.vaporwave::after{
   background:
     repeating-linear-gradient(to right, rgba(1,241,248,.9) 0 10px, rgba(1,241,248,0) 10px 300px),
     repeating-linear-gradient(to bottom, rgba(1,241,248,.9) 0 10px, rgba(1,241,248,0) 10px 300px);
+  background-size: 300px 300px, 300px 300px;
   filter: drop-shadow(0 0 10px rgba(1,241,248,.4)) drop-shadow(0 0 14px rgba(1,241,248,.32));
 
   transform-origin: 50% 100%;
@@ -107,7 +108,7 @@ body.vaporwave::after{
   -webkit-mask: linear-gradient(to top, black 0 58%, transparent 90%);
           mask: linear-gradient(to top, black 0 58%, transparent 90%);
 
-  animation: gridDrift 20s linear infinite;
+  animation: gridDrift 20s steps(200) infinite;
 }
 
 @supports not ((mask: linear-gradient(#000,#000)) or (-webkit-mask: linear-gradient(#000,#000))){


### PR DESCRIPTION
## Summary
- preload grid and sun backgrounds via canvas to avoid flicker
- step animations ensure grid drift stays on whole pixels

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b61c0f46a083308d867aac2eb8c29e