### PR TITLE
Ensure sun background fills element

### DIFF
--- a/static/bg-cache.js
+++ b/static/bg-cache.js
@@ -72,6 +72,8 @@ document.addEventListener('DOMContentLoaded', () => {
   if (sunEl) {
     const sunURL = makeSunImage();
     sunEl.style.backgroundImage = `url(${sunURL})`;
+    sunEl.style.backgroundRepeat = 'no-repeat';
+    sunEl.style.backgroundSize = '100% 100%';
     sunEl.style.webkitMask = 'none';
     sunEl.style.mask = 'none';
   }


### PR DESCRIPTION
## Summary
- Prevent sun background from tiling by setting `backgroundRepeat` to `no-repeat`
- Force sun background to fill its element with `backgroundSize: 100% 100%`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b629dafd588330865cac19614a3d06