### PR TITLE
Thicken and extend sun scanlines

### DIFF
--- a/static/bg-cache.js
+++ b/static/bg-cache.js
@@ -47,8 +47,8 @@ document.addEventListener('DOMContentLoaded', () => {
     mask.width = mask.height = size;
     const mCtx = mask.getContext('2d');
     mCtx.fillStyle = '#000';
-    for (let y = 0; y < size; y += 16) {
-      mCtx.fillRect(0, y, size, 10);
+    for (let y = 0; y < size; y += 22) {
+      mCtx.fillRect(0, y, size, 14);
     }
     mCtx.globalCompositeOperation = 'destination-in';
     mCtx.beginPath();

--- a/static/vaporwave.css
+++ b/static/vaporwave.css
@@ -67,10 +67,21 @@ body.vaporwave{
   /* scanline mask */
   -webkit-mask:
     radial-gradient(circle at 50% 50%, #000 99%, transparent 100%) /* crisp circular edge */ ,
-    repeating-linear-gradient(to bottom, #000 0 10px, transparent 10px 16px);
+    repeating-linear-gradient(to bottom, #000 0 14px, transparent 14px 22px);
   -webkit-mask-composite: source-in; /* keep stripes inside the circle */
           mask-composite: intersect;
   animation: sunFloat 16s steps(120) infinite alternate;
+}
+
+.bg-sunset::before{
+  content:"";
+  position:absolute;
+  inset:-40%;
+  border-radius:50%;
+  pointer-events:none;
+  background:repeating-linear-gradient(to bottom, rgba(0,0,0,0.3) 0 14px, transparent 14px 22px);
+  -webkit-mask:radial-gradient(circle at 50% 50%, transparent 56%, #000 56%);
+          mask:radial-gradient(circle at 50% 50%, transparent 56%, #000 56%);
 }
 
 /* Horizon haze sits between sky and grid to soften the join */


### PR DESCRIPTION
## Summary
- Thicken sunset scanlines for stronger retro styling
- Extend scanlines beyond the sun to overlay the glow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b70616a8ac8330972cd9628b46720d