### PR TITLE
refactor halo stripes with clip-path

### DIFF
--- a/static/vaporwave.css
+++ b/static/vaporwave.css
@@ -80,8 +80,8 @@ body.vaporwave{
   border-radius:50%;
   pointer-events:none;
   background:repeating-linear-gradient(to bottom, rgba(0,0,0,0.3) 0 14px, transparent 14px 22px);
-  -webkit-mask:radial-gradient(circle at 50% 50%, transparent 56%, #000 56%);
-          mask:radial-gradient(circle at 50% 50%, transparent 56%, #000 56%);
+  -webkit-clip-path:circle(70%);
+          clip-path:circle(70%);
 }
 
 /* Horizon haze sits between sky and grid to soften the join */


### PR DESCRIPTION
## Summary
- confine sunset halo stripes with `clip-path` for better cross-browser support

## Testing
- `pytest -q`
- Attempted `playwright install chromium firefox` *(fails: Domain forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b70a56667c8330882d72ca9b009d24