### PR TITLE
Use CSS mask for sun scanlines

### DIFF
--- a/static/bg-cache.js
+++ b/static/bg-cache.js
@@ -1,6 +1,4 @@
 document.addEventListener('DOMContentLoaded', () => {
-  const rootStyles = getComputedStyle(document.documentElement);
-
   function makeGridImages() {
     const size = 300;
     const color = 'rgba(1,241,248,0.9)';
@@ -24,58 +22,10 @@ document.addEventListener('DOMContentLoaded', () => {
     return { vURL, hURL };
   }
 
-  function makeSunImage() {
-    const size = 512;
-    const canvas = document.createElement('canvas');
-    canvas.width = canvas.height = size;
-    const ctx = canvas.getContext('2d');
-
-    const core = rootStyles.getPropertyValue('--sun-core').trim() || '#ffd29a';
-    const rim = rootStyles.getPropertyValue('--sun-rim').trim() || '#ff6a4d';
-
-    const grad = ctx.createRadialGradient(size / 2, size / 2, 0, size / 2, size / 2, size / 2);
-    grad.addColorStop(0, '#fff6d2');
-    grad.addColorStop(0.38, core);
-    grad.addColorStop(0.62, '#ff9c66');
-    grad.addColorStop(0.85, rim);
-    grad.addColorStop(1, rim);
-    ctx.fillStyle = grad;
-    ctx.fillRect(0, 0, size, size);
-
-    // build stripe mask and clip with circle
-    const mask = document.createElement('canvas');
-    mask.width = mask.height = size;
-    const mCtx = mask.getContext('2d');
-    mCtx.fillStyle = '#000';
-    for (let y = 0; y < size; y += 22) {
-      mCtx.fillRect(0, y, size, 14);
-    }
-    mCtx.globalCompositeOperation = 'destination-in';
-    mCtx.beginPath();
-    mCtx.arc(size / 2, size / 2, size / 2, 0, Math.PI * 2);
-    mCtx.closePath();
-    mCtx.fill();
-
-    ctx.globalCompositeOperation = 'destination-in';
-    ctx.drawImage(mask, 0, 0);
-
-    return canvas.toDataURL();
-  }
-
   const gridEl = document.querySelector('.bg-grid');
   if (gridEl) {
     const { vURL, hURL } = makeGridImages();
     gridEl.style.backgroundImage = `url(${vURL}), url(${hURL})`;
     gridEl.style.backgroundSize = '300px 300px, 300px 300px';
-  }
-
-  const sunEl = document.querySelector('.bg-sunset');
-  if (sunEl) {
-    const sunURL = makeSunImage();
-    sunEl.style.backgroundImage = `url(${sunURL})`;
-    sunEl.style.backgroundRepeat = 'no-repeat';
-    sunEl.style.backgroundSize = '100% 100%';
-    sunEl.style.webkitMask = 'none';
-    sunEl.style.mask = 'none';
   }
 });

--- a/static/vaporwave.css
+++ b/static/vaporwave.css
@@ -15,6 +15,8 @@
   --sky-b:#a14bff;     /* magenta */
   --sky-c:#ff8c42;     /* orange horizon */
   --haze:#ffd0f0;      /* subtle mist */
+  --sun-stripe:14px;
+  --sun-gap:8px;
   /* viewport relative units */
   --vw: 1vw;
   --vh: 1vh;
@@ -67,7 +69,11 @@ body.vaporwave{
   /* scanline mask */
   -webkit-mask:
     radial-gradient(circle at 50% 50%, #000 99%, transparent 100%) /* crisp circular edge */ ,
-    repeating-linear-gradient(to bottom, #000 0 14px, transparent 14px 22px);
+    repeating-linear-gradient(
+      to bottom,
+      #000 0 var(--sun-stripe),
+      transparent var(--sun-stripe) calc(var(--sun-stripe) + var(--sun-gap))
+    );
   -webkit-mask-composite: source-in; /* keep stripes inside the circle */
           mask-composite: intersect;
   animation: sunFloat 16s steps(120) infinite alternate;
@@ -79,7 +85,11 @@ body.vaporwave{
   inset:-40%;
   border-radius:50%;
   pointer-events:none;
-  background:repeating-linear-gradient(to bottom, rgba(0,0,0,0.3) 0 14px, transparent 14px 22px);
+  background:repeating-linear-gradient(
+    to bottom,
+    rgba(0,0,0,0.3) 0 var(--sun-stripe),
+    transparent var(--sun-stripe) calc(var(--sun-stripe) + var(--sun-gap))
+  );
   -webkit-mask:radial-gradient(circle at 50% 50%, transparent 56%, #000 56%);
           mask:radial-gradient(circle at 50% 50%, transparent 56%, #000 56%);
 }


### PR DESCRIPTION
## Summary
- rely on CSS masking for the sunset scanlines and drop the canvas-generated sun
- centralize stripe thickness and spacing with CSS variables
- keep grid cache script focused only on neon grid images

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b70a56a0388330bd7eef2e89b06b82