### PR TITLE
Add model switch UI

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -14,10 +14,18 @@
   <div class="bg-sunset" aria-hidden="true"></div>
   <div class="bg-grid" aria-hidden="true"></div>
 
-  <header class="site-header">
-    <h1 class="title">Tone Coach</h1>
-    <p class="subtitle">Neon clarity for your inbox</p>
-  </header>
+    <header class="site-header">
+      <h1 class="title">Tone Coach</h1>
+      <p class="subtitle">Neon clarity for your inbox</p>
+      <div class="model-toggle">
+        <span class="model-label">llama3.1</span>
+        <label class="switch">
+          <input type="checkbox" id="model-toggle" />
+          <span class="slider"></span>
+        </label>
+        <span class="model-label">gpt-5</span>
+      </div>
+    </header>
 
   <main class="grid-container">
     <section class="panel panel--inbox">
@@ -70,11 +78,12 @@
       const threadBox = document.querySelector('.thread-box');
       const coachBtn = document.querySelector('.coach-btn');
       const identifyBtn = document.querySelector('.identify-btn');
-      const outputBox = document.querySelector('.output-box');
-      const timerEl = document.querySelector('.timer');
-      const draftInput = document.querySelector('#draft');
-      const goalInput = document.querySelector('.goal');
-      const searchInput = document.querySelector('input.search');
+        const outputBox = document.querySelector('.output-box');
+        const timerEl = document.querySelector('.timer');
+        const draftInput = document.querySelector('#draft');
+        const goalInput = document.querySelector('.goal');
+        const searchInput = document.querySelector('input.search');
+        const modelToggle = document.querySelector('#model-toggle');
 
       let timerHandle;
 
@@ -178,6 +187,11 @@
           identifyBtn.disabled = false;
           identifyBtn.querySelector('span:last-child').textContent = 'Identify';
         }
+      });
+
+      modelToggle.addEventListener('change', () => {
+        const mode = modelToggle.checked ? 'GPT-5 API' : 'local llama3.1';
+        console.log(`Model switch set to ${mode}`);
       });
     });
   </script>

--- a/static/vaporwave.css
+++ b/static/vaporwave.css
@@ -234,6 +234,61 @@ body.vaporwave::after{
   opacity:0.8;
 }
 
+/* Model switch */
+.model-toggle{
+  margin-top:10px;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  gap:8px;
+  font-family:Orbitron, Inter, sans-serif;
+  font-size:12px;
+}
+
+.model-toggle .switch{
+  position:relative;
+  width:44px;
+  height:24px;
+}
+
+.model-toggle .switch input{
+  opacity:0;
+  width:0;
+  height:0;
+}
+
+.model-toggle .slider{
+  position:absolute;
+  cursor:pointer;
+  top:0;
+  left:0;
+  right:0;
+  bottom:0;
+  background:var(--neon-pink);
+  border-radius:24px;
+  transition:background .3s;
+}
+
+.model-toggle .slider:before{
+  position:absolute;
+  content:"";
+  height:18px;
+  width:18px;
+  left:3px;
+  bottom:3px;
+  background:#fff;
+  border-radius:50%;
+  transition:transform .3s;
+}
+
+.model-toggle input:checked + .slider{
+  background:var(--neon-cyan);
+}
+
+.model-toggle input:checked + .slider:before{
+  transform:translateX(20px);
+}
+
 .site-footer{
   text-align:center;
   padding: 20px 0 32px;


### PR DESCRIPTION
## Summary
- add a model selector toggle to header allowing choice between local llama3.1 and GPT-5 API
- style toggle in vaporwave theme and log selected model

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7227616488330b697a0ed9f71c382