### PR TITLE
Guard stream chunks that lack choices

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -291,11 +291,12 @@ def coach():
             **stream_kwargs,
         )
         for chunk in stream:
-            text = getattr(chunk.choices[0].delta, "content", "")
-            if text:
-                output += text
-                yield text
-            if use_openai and getattr(chunk, "usage", None) is not None:
+            if getattr(chunk, "choices", None):
+                text = getattr(chunk.choices[0].delta, "content", "")
+                if text:
+                    output += text
+                    yield text
+            if use_openai and getattr(chunk, "usage", None):
                 usage_info = chunk.usage
         log_usage(prompt, output, usage_info, model, use_openai)
         match = re.search(r"(?s)(?:^|\n)Beta\s*[:\-]?\s*(.*)", output)
@@ -348,11 +349,12 @@ def madlibs():
             **stream_kwargs,
         )
         for chunk in stream:
-            text = getattr(chunk.choices[0].delta, "content", "")
-            if text:
-                output += text
-                yield text
-            if use_openai and getattr(chunk, "usage", None) is not None:
+            if getattr(chunk, "choices", None):
+                text = getattr(chunk.choices[0].delta, "content", "")
+                if text:
+                    output += text
+                    yield text
+            if use_openai and getattr(chunk, "usage", None):
                 usage_info = chunk.usage
         log_usage(prompt, output, usage_info, model, use_openai)
         match = re.search(r"(?s)Template\s*[:\-]?\s*(.*)", output)


### PR DESCRIPTION
## Summary
- Avoid crashes when streaming responses include chunks without `choices`
- Record usage information from OpenAI streams even when some chunks lack choices

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7448bb5e88330854718b6e6dbe35d